### PR TITLE
Create organization variable set to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "aws_service_access_principals" {
 
 variable "create_organization" {
   type        = bool
-  default     = true
+  default     = false
   description = "Whether or not to use this module to create your AWS organization."
 }
 


### PR DESCRIPTION
This variable is used to set organization status if it doesn't exisits it creates one but because we already have one we set it to false